### PR TITLE
HttpGet support Alt-Svc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ Agent of Nezha Monitoring
 
 <!--GAMFC_DELIMITER--><a href="https://github.com/naiba" title="naiba">
   <img src="https://avatars.githubusercontent.com/u/29243953?v=4" width="50;" alt="naiba"/>
+</a>
+<a href="https://github.com/zhangnew" title="zhangnew">
+  <img src="https://avatars.githubusercontent.com/u/9146834?v=4" width="50;" alt="zhangnew"/>
 </a><!--GAMFC_DELIMITER_END-->

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/creack/pty v1.1.18
 	github.com/dean2021/goss v0.0.0-20230129073947-df90431348f1
+	github.com/ebi-yade/altsvc-go v0.1.1
 	github.com/go-ping/ping v1.1.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/iamacarpet/go-winpty v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dean2021/goss v0.0.0-20230129073947-df90431348f1 h1:5UiJ324LiCdOF/3w/5IeXrKVjdnwHoalvLG2smb3wi4=
 github.com/dean2021/goss v0.0.0-20230129073947-df90431348f1/go.mod h1:NiLueuVb3hYcdF4ta+2ezcKJh6BEjhrBz9Hts6XJ5Sc=
+github.com/ebi-yade/altsvc-go v0.1.1 h1:HmZDNb5ZOPlkyXhi34LnRckawFCux7yPYw+dtInIixo=
+github.com/ebi-yade/altsvc-go v0.1.1/go.mod h1:K/U20bLcsOVrbTeDhqRjp+e3tgNT5iAqSiQzPoU0/Q0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ type AgentCliParam struct {
 	ClientSecret          string // 客户端密钥
 	ReportDelay           int    // 报告间隔
 	TLS                   bool   // 是否使用TLS加密传输至服务端
+	Version               bool   // 当前版本号
 }
 
 var (
@@ -157,7 +158,13 @@ func main() {
 	flag.BoolVar(&agentCliParam.DisableAutoUpdate, "disable-auto-update", false, "禁用自动升级")
 	flag.BoolVar(&agentCliParam.DisableForceUpdate, "disable-force-update", false, "禁用强制升级")
 	flag.BoolVar(&agentCliParam.TLS, "tls", false, "启用SSL/TLS加密")
+	flag.BoolVarP(&agentCliParam.Version, "version", "v", false, "查看当前版本号")
 	flag.Parse()
+
+	if agentCliParam.Version {
+		fmt.Println(version)
+		return
+	}
 
 	if isEditAgentConfig {
 		editAgentConfig()


### PR DESCRIPTION
The [Alt-Svc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc) HTTP header allows a server to indicate that another network location (the "alternative service") can be treated as authoritative for that origin when making future requests.

see also https://httpwg.org/specs/rfc7838.html