### PR TITLE
添加多路CPU核心数统计

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -59,13 +59,13 @@ func GetHost(agentConfig *model.AgentConfig) *model.Host {
 	}
 
 	ci, err := cpu.Info()
+	count := int32(0)
 	if err != nil {
 		println("cpu.Info error:", err)
-	}
-	count, err := cpu.Counts(false)
-	if err != nil {
-		println("cpu.Counts error:", err)
 	} else if len(ci) > 0 {
+		for i:=0; i < len(ci); i++ {
+			count += ci[i].Cores
+		}
 		ret.CPU = append(ret.CPU, fmt.Sprintf("%s %d %s Core", ci[0].ModelName, count, cpuType))
 	}
 


### PR DESCRIPTION
由于cpu.Counts不支持多路，只好改成使用ci.Cores