### PR TITLE
指定 go1.20.13

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.20.0"
+          go-version: "1.20.13"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.20.0"
+          go-version: "1.20.13"
       - name: Unit test
         run: |
           go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.20.0"
+          go-version: "1.20.13"
       - name: Unit test
         run: |
           go test -v ./...


### PR DESCRIPTION
指定 `go-version` 为 `1.20.13` 以防止编译时使用 1.21 的最新版，进而导致 Windows 7 等系统无法启动