### PR TITLE
feat: make ip update period modifiable

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ type AgentCliParam struct {
 	ReportDelay           int    // 报告间隔
 	TLS                   bool   // 是否使用TLS加密传输至服务端
 	Version               bool   // 当前版本号
+	IPReportPeriod        uint32 // 上报IP间隔
 }
 
 var (
@@ -164,6 +165,7 @@ func main() {
 	flag.BoolVar(&agentCliParam.DisableForceUpdate, "disable-force-update", false, "禁用强制升级")
 	flag.BoolVar(&agentCliParam.TLS, "tls", false, "启用SSL/TLS加密")
 	flag.BoolVarP(&agentCliParam.Version, "version", "v", false, "查看当前版本号")
+	flag.Uint32VarP(&agentCliParam.IPReportPeriod, "ip-report-period", "u", 30*60, "IP上报间隔")
 	flag.Parse()
 
 	if agentCliParam.Version {
@@ -201,7 +203,7 @@ func run() {
 	// 上报服务器信息
 	go reportState()
 	// 更新IP信息
-	go monitor.UpdateIP()
+	go monitor.UpdateIP(agentCliParam.IPReportPeriod)
 
 	// 定时检查更新
 	if _, err := semver.Parse(version); err == nil && !agentCliParam.DisableAutoUpdate {

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -53,13 +54,18 @@ var (
 	httpClientV6            = util.NewSingleStackHTTPClient(time.Second*20, time.Second*5, time.Second*10, true)
 )
 
-// UpdateIP 每30分钟更新一次IP地址与国家码的缓存
-func UpdateIP() {
+// UpdateIP 按设置时间间隔更新IP地址与国家码的缓存
+func UpdateIP(period uint32) {
 	for {
+		log.Println("NEZHA_AGENT>> 正在上报IP信息")
 		ipv4 := fetchGeoIP(geoIPApiList, false)
 		ipv6 := fetchGeoIP(geoIPApiList, true)
 		if ipv4.IP == "" && ipv6.IP == "" {
-			time.Sleep(time.Minute)
+			if period > 60 {
+				time.Sleep(time.Minute)
+			} else {
+				time.Sleep(time.Second * time.Duration(period))
+			}
 			continue
 		}
 		if ipv4.IP == "" || ipv6.IP == "" {
@@ -72,7 +78,7 @@ func UpdateIP() {
 		} else if ipv6.CountryCode != "" {
 			cachedCountry = ipv6.CountryCode
 		}
-		time.Sleep(time.Minute * 30)
+		time.Sleep(time.Second * time.Duration(period))
 	}
 }
 


### PR DESCRIPTION
Added a new program argument `ip-report-period` or `u`.

The default value is set to 1800 secs to make default behavior is same as before.

## Why Need to Make Changes
See this PR 
https://github.com/naiba/nezha/pull/324