### PR TITLE
fix virtualization detection

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -54,7 +54,11 @@ func GetHost(agentConfig *model.AgentConfig) *model.Host {
 		ret.Platform = hi.Platform
 		ret.PlatformVersion = hi.PlatformVersion
 		ret.Arch = hi.KernelArch
-		ret.Virtualization = hi.VirtualizationSystem
+		if cpuType == "Physical" {
+			ret.Virtualization = ""
+		} else {
+			ret.Virtualization = hi.VirtualizationSystem
+		}
 		ret.BootTime = hi.BootTime
 	}
 


### PR DESCRIPTION
Fix virtualization detection behavior: When `CpuType` is equal to Physical, `ret.Virtualization` should be an empty string.