### PR TITLE
Fix ret.CPU detection on various platforms

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -67,11 +67,15 @@ func GetHost(agentConfig *model.AgentConfig) *model.Host {
 	if err != nil {
 		println("cpu.Info error:", err)
 	} else {
-		for i := 0; i < len(ci); i++ {
-			cpuModelCount[ci[i].ModelName]++
-		}
-		for model, count := range cpuModelCount {
-			ret.CPU = append(ret.CPU, fmt.Sprintf("%s %d %s Core", model, count, cpuType))
+		if runtime.GOOS == "linux" && runtime.GOOS == "windows" {
+			for i := 0; i < len(ci); i++ {
+				cpuModelCount[ci[i].ModelName]++
+			}
+			for model, count := range cpuModelCount {
+				ret.CPU = append(ret.CPU, fmt.Sprintf("%s %d %s Core", model, count, cpuType))
+			}
+		} else {
+			ret.CPU = append(ret.CPU, fmt.Sprintf("%s %d %s Core", ci[0].ModelName, ci[0].Cores, cpuType))
 		}
 	}
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -67,7 +67,7 @@ func GetHost(agentConfig *model.AgentConfig) *model.Host {
 	if err != nil {
 		println("cpu.Info error:", err)
 	} else {
-		if runtime.GOOS == "linux" && runtime.GOOS == "windows" {
+		if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
 			for i := 0; i < len(ci); i++ {
 				cpuModelCount[ci[i].ModelName]++
 			}


### PR DESCRIPTION
The current detection method for platforms other than Linux and Windows malfunctions due to the absence of multiple lines of `cpu.Info` in `gopsutil`, as this feature is not implemented for those platforms.