### PR TITLE
fix: wrong IP value in some situations

### DIFF
--- a/pkg/gpu/stat/amd_rocm_smi.go
+++ b/pkg/gpu/stat/amd_rocm_smi.go
@@ -4,11 +4,12 @@ package stat
 // Original License: MIT
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"strconv"
+
+	"github.com/nezhahq/agent/pkg/util"
 )
 
 type ROCmSMI struct {
@@ -48,7 +49,7 @@ func gatherROCmSMI(ret []byte) ([]float64, error) {
 	var gpus map[string]GPU
 	var percentage []float64
 
-	err := json.Unmarshal(ret, &gpus)
+	err := util.Json.Unmarshal(ret, &gpus)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -100,21 +100,23 @@ func fetchGeoIP(servers []string, isV6 bool) geoIP {
 				continue
 			}
 			resp.Body.Close()
-			if err := ip.Unmarshal(body); err != nil {
+			newIP := geoIP{}
+			if err := newIP.Unmarshal(body); err != nil {
 				continue
 			}
 			// 没取到 v6 IP
-			if isV6 && !strings.Contains(ip.IP, ":") {
+			if isV6 && !strings.Contains(newIP.IP, ":") {
 				continue
 			}
 			// 没取到 v4 IP
-			if !isV6 && !strings.Contains(ip.IP, ".") {
+			if !isV6 && !strings.Contains(newIP.IP, ".") {
 				continue
 			}
 			// 未获取到国家码
-			if ip.CountryCode == "" {
+			if newIP.CountryCode == "" {
 				continue
 			}
+			ip = newIP
 			return ip
 		}
 	}


### PR DESCRIPTION
在某些情况下（例如启用一些代理软件的FakeDNS功能），即使指定了v6解析，从GeoIP API获取的IP也是v4地址
原来的方式有一点问题，导致后面判断实际上没起到作用，所以会出现`ipv4.IP`和`ipv6.IP`都是ipv4地址的情况

其它的修改：把 `pkg/gpu/stat/amd_rocm_smi.go` 的 `encoding/json` 换成util里已导入的 `jsoniter` 库了