### PR TITLE
Add --ipv6-countrycode runtime parameter to set the region flag using IPv6 by default

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -53,7 +53,7 @@ type AgentCliParam struct {
 	InsecureTLS           bool   // 是否禁用证书检查
 	Version               bool   // 当前版本号
 	IPReportPeriod        uint32 // 上报IP间隔
-	IPv6CountryCode       bool   // 默认优先展示IPv6旗帜
+	UseIPv6CountryCode       bool   // 默认优先展示IPv6旗帜
 }
 
 var (
@@ -150,7 +150,7 @@ func init() {
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableCommandExecute, "disable-command-execute", false, "禁止在此机器上执行命令")
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableAutoUpdate, "disable-auto-update", false, "禁用自动升级")
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableForceUpdate, "disable-force-update", false, "禁用强制升级")
-	agentCmd.PersistentFlags().BoolVar(&agentCliParam.IPv6CountryCode, "ipv6-countrycode", false, "默认优先展示IPv6旗帜")
+	agentCmd.PersistentFlags().BoolVar(&agentCliParam.UseIPv6CountryCode, "use-ipv6-countrycode", false, "使用IPv6的位置上报")
 	agentCmd.PersistentFlags().BoolVar(&agentConfig.GPU, "gpu", false, "启用GPU监控")
 	agentCmd.PersistentFlags().Uint32VarP(&agentCliParam.IPReportPeriod, "ip-report-period", "u", 30*60, "本地IP更新间隔, 上报频率依旧取决于report-delay的值")
 	agentCmd.Flags().BoolVarP(&agentCliParam.Version, "version", "v", false, "查看当前版本号")
@@ -219,7 +219,7 @@ func run() {
 	// 上报服务器信息
 	go reportState()
 	// 更新IP信息
-	go monitor.UpdateIP(agentCliParam.IPv6CountryCode, agentCliParam.IPReportPeriod)
+	go monitor.UpdateIP(agentCliParam.UseIPv6CountryCode, agentCliParam.IPReportPeriod)
 
 	// 定时检查更新
 	if _, err := semver.Parse(version); err == nil && !agentCliParam.DisableAutoUpdate {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -53,6 +53,7 @@ type AgentCliParam struct {
 	InsecureTLS           bool   // 是否禁用证书检查
 	Version               bool   // 当前版本号
 	IPReportPeriod        uint32 // 上报IP间隔
+	IPv6CountryCode       bool   // 默认优先展示IPv6旗帜
 }
 
 var (
@@ -149,6 +150,7 @@ func init() {
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableCommandExecute, "disable-command-execute", false, "禁止在此机器上执行命令")
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableAutoUpdate, "disable-auto-update", false, "禁用自动升级")
 	agentCmd.PersistentFlags().BoolVar(&agentCliParam.DisableForceUpdate, "disable-force-update", false, "禁用强制升级")
+	agentCmd.PersistentFlags().BoolVar(&agentCliParam.IPv6CountryCode, "ipv6-countrycode", false, "默认优先展示IPv6旗帜")
 	agentCmd.PersistentFlags().BoolVar(&agentConfig.GPU, "gpu", false, "启用GPU监控")
 	agentCmd.PersistentFlags().Uint32VarP(&agentCliParam.IPReportPeriod, "ip-report-period", "u", 30*60, "本地IP更新间隔, 上报频率依旧取决于report-delay的值")
 	agentCmd.Flags().BoolVarP(&agentCliParam.Version, "version", "v", false, "查看当前版本号")
@@ -217,7 +219,7 @@ func run() {
 	// 上报服务器信息
 	go reportState()
 	// 更新IP信息
-	go monitor.UpdateIP(agentCliParam.IPReportPeriod)
+	go monitor.UpdateIP(agentCliParam.IPv6CountryCode, agentCliParam.IPReportPeriod)
 
 	// 定时检查更新
 	if _, err := semver.Parse(version); err == nil && !agentCliParam.DisableAutoUpdate {

--- a/cmd/agent/service.go
+++ b/cmd/agent/service.go
@@ -86,6 +86,7 @@ func serviceActions(cmd *cobra.Command, args []string) {
 		{agentCliParam.DisableCommandExecute, "--disable-command-execute", ""},
 		{agentCliParam.DisableAutoUpdate, "--disable-auto-update", ""},
 		{agentCliParam.DisableForceUpdate, "--disable-force-update", ""},
+		{agentCliParam.IPv6CountryCode, "--ipv6-countrycode", ""},
 		{agentConfig.GPU, "--gpu", ""},
 		{agentCliParam.IPReportPeriod != 30*60, "-u", fmt.Sprint(agentCliParam.IPReportPeriod)},
 	}

--- a/cmd/agent/service.go
+++ b/cmd/agent/service.go
@@ -86,7 +86,7 @@ func serviceActions(cmd *cobra.Command, args []string) {
 		{agentCliParam.DisableCommandExecute, "--disable-command-execute", ""},
 		{agentCliParam.DisableAutoUpdate, "--disable-auto-update", ""},
 		{agentCliParam.DisableForceUpdate, "--disable-force-update", ""},
-		{agentCliParam.IPv6CountryCode, "--ipv6-countrycode", ""},
+		{agentCliParam.UseIPv6CountryCode, "--use-ipv6-countrycode", ""},
 		{agentConfig.GPU, "--gpu", ""},
 		{agentCliParam.IPReportPeriod != 30*60, "-u", fmt.Sprint(agentCliParam.IPReportPeriod)},
 	}

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -55,11 +55,11 @@ var (
 )
 
 // UpdateIP 按设置时间间隔更新IP地址与国家码的缓存
-func UpdateIP(IPV6CountryCode bool, period uint32) {
+func UpdateIP(useIPv6CountryCode bool, period uint32) {
 	for {
 		log.Println("NEZHA_AGENT>> 正在更新本地缓存IP信息")
 		var primaryIP, secondaryIP geoIP
-		if IPV6CountryCode {
+		if useIPv6CountryCode {
 			primaryIP = fetchGeoIP(geoIPApiList, true)
 			secondaryIP = fetchGeoIP(geoIPApiList, false)
 		} else {

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -55,12 +55,19 @@ var (
 )
 
 // UpdateIP 按设置时间间隔更新IP地址与国家码的缓存
-func UpdateIP(period uint32) {
+func UpdateIP(IPV6CountryCode bool, period uint32) {
 	for {
 		log.Println("NEZHA_AGENT>> 正在更新本地缓存IP信息")
-		ipv4 := fetchGeoIP(geoIPApiList, false)
-		ipv6 := fetchGeoIP(geoIPApiList, true)
-		if ipv4.IP == "" && ipv6.IP == "" {
+		var primaryIP, secondaryIP geoIP
+		if IPV6CountryCode {
+			primaryIP = fetchGeoIP(geoIPApiList, true)
+			secondaryIP = fetchGeoIP(geoIPApiList, false)
+		} else {
+			primaryIP = fetchGeoIP(geoIPApiList, false)
+			secondaryIP = fetchGeoIP(geoIPApiList, true)
+		}
+
+		if primaryIP.IP == "" && secondaryIP.IP == "" {
 			if period > 60 {
 				time.Sleep(time.Minute)
 			} else {
@@ -68,15 +75,16 @@ func UpdateIP(period uint32) {
 			}
 			continue
 		}
-		if ipv4.IP == "" || ipv6.IP == "" {
-			CachedIP = fmt.Sprintf("%s%s", ipv4.IP, ipv6.IP)
+		if primaryIP.IP == "" || secondaryIP.IP == "" {
+			CachedIP = fmt.Sprintf("%s%s", primaryIP.IP, secondaryIP.IP)
 		} else {
-			CachedIP = fmt.Sprintf("%s/%s", ipv4.IP, ipv6.IP)
+			CachedIP = fmt.Sprintf("%s/%s", primaryIP.IP, secondaryIP.IP)
 		}
-		if ipv4.CountryCode != "" {
-			cachedCountry = ipv4.CountryCode
-		} else if ipv6.CountryCode != "" {
-			cachedCountry = ipv6.CountryCode
+
+		if primaryIP.CountryCode != "" {
+			cachedCountry = primaryIP.CountryCode
+		} else if secondaryIP.CountryCode != "" {
+			cachedCountry = secondaryIP.CountryCode
 		}
 		time.Sleep(time.Second * time.Duration(period))
 	}


### PR DESCRIPTION
现在很多IDC提供的双栈服务器IPv4/IPv6出口可能不属于同一个地区，针对这种情况，本PR增加了--ipv6-countrycode参数，使用户可以自行决定是否优先使用IPv6的地区作为默认，展示旗帜。原始版本强制优先使用IPv4，缺乏灵活性。