### PR TITLE
some code refactor

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -38,6 +38,7 @@ import (
 	pb "github.com/nezhahq/agent/proto"
 )
 
+// Agent 运行时参数。如需添加新参数，记得同时在 service.go 中添加
 type AgentCliParam struct {
 	SkipConnectionCount   bool   // 跳过连接数检查
 	SkipProcsCount        bool   // 跳过进程数量检查

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -433,7 +433,9 @@ func reportState() {
 
 // doSelfUpdate 执行更新检查 如果更新成功则会结束进程
 func doSelfUpdate(useLocalVersion bool) {
-	<-monitor.Sync
+	if monitor.CachedCountry == "" {
+		return
+	}
 	v := semver.MustParse("0.1.0")
 	if useLocalVersion {
 		v = semver.MustParse(version)

--- a/cmd/agent/service.go
+++ b/cmd/agent/service.go
@@ -86,6 +86,7 @@ func serviceActions(cmd *cobra.Command, args []string) {
 		{agentCliParam.DisableForceUpdate, "--disable-force-update", ""},
 		{agentCliParam.UseIPv6CountryCode, "--use-ipv6-countrycode", ""},
 		{agentConfig.GPU, "--gpu", ""},
+		{agentCliParam.UseGiteeToUpgrade, "--gitee", ""},
 		{agentCliParam.IPReportPeriod != 30*60, "-u", fmt.Sprint(agentCliParam.IPReportPeriod)},
 	}
 

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -49,7 +49,6 @@ var (
 		// "https://freegeoip.app/json/", // 需要 Key
 	}
 	CachedIP, CachedCountry string
-	Sync                    = make(chan bool)
 	httpClientV4            = util.NewSingleStackHTTPClient(time.Second*20, time.Second*5, time.Second*10, false)
 	httpClientV6            = util.NewSingleStackHTTPClient(time.Second*20, time.Second*5, time.Second*10, true)
 )
@@ -75,15 +74,11 @@ func UpdateIP(useIPv6CountryCode bool, period uint32) {
 			CachedIP = fmt.Sprintf("%s/%s", ipv4.IP, ipv6.IP)
 		}
 
-		if ipv4.CountryCode != "" && !useIPv6CountryCode {
+		if ipv4.CountryCode != "" {
 			CachedCountry = ipv4.CountryCode
-		} else if ipv6.CountryCode != "" && useIPv6CountryCode {
-			CachedCountry = ipv6.CountryCode
 		}
-
-		select {
-		case Sync <- true:
-		default:
+		if ipv6.CountryCode != "" && (useIPv6CountryCode || CachedCountry == "") {
+			CachedCountry = ipv6.CountryCode
 		}
 
 		time.Sleep(time.Second * time.Duration(period))

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -58,16 +58,10 @@ var (
 func UpdateIP(useIPv6CountryCode bool, period uint32) {
 	for {
 		util.Println(agentConfig.Debug, "正在更新本地缓存IP信息")
-		var primaryIP, secondaryIP geoIP
-		if useIPv6CountryCode {
-			primaryIP = fetchGeoIP(geoIPApiList, true)
-			secondaryIP = fetchGeoIP(geoIPApiList, false)
-		} else {
-			primaryIP = fetchGeoIP(geoIPApiList, false)
-			secondaryIP = fetchGeoIP(geoIPApiList, true)
-		}
+		ipv4 := fetchGeoIP(geoIPApiList, false)
+		ipv6 := fetchGeoIP(geoIPApiList, true)
 
-		if primaryIP.IP == "" && secondaryIP.IP == "" {
+		if ipv4.IP == "" && ipv6.IP == "" {
 			if period > 60 {
 				time.Sleep(time.Minute)
 			} else {
@@ -75,16 +69,16 @@ func UpdateIP(useIPv6CountryCode bool, period uint32) {
 			}
 			continue
 		}
-		if primaryIP.IP == "" || secondaryIP.IP == "" {
-			CachedIP = fmt.Sprintf("%s%s", primaryIP.IP, secondaryIP.IP)
+		if ipv4.IP == "" || ipv6.IP == "" {
+			CachedIP = fmt.Sprintf("%s%s", ipv4.IP, ipv6.IP)
 		} else {
-			CachedIP = fmt.Sprintf("%s/%s", primaryIP.IP, secondaryIP.IP)
+			CachedIP = fmt.Sprintf("%s/%s", ipv4.IP, ipv6.IP)
 		}
 
-		if primaryIP.CountryCode != "" {
-			CachedCountry = primaryIP.CountryCode
-		} else if secondaryIP.CountryCode != "" {
-			CachedCountry = secondaryIP.CountryCode
+		if ipv4.CountryCode != "" && !useIPv6CountryCode {
+			CachedCountry = ipv4.CountryCode
+		} else if ipv6.CountryCode != "" && useIPv6CountryCode {
+			CachedCountry = ipv6.CountryCode
 		}
 
 		select {

--- a/pkg/pty/pty_windows.go
+++ b/pkg/pty/pty_windows.go
@@ -58,9 +58,8 @@ func VersionCheck() bool {
 		}
 
 		return version >= 17763
-	} else {
-		return false
 	}
+	return false
 }
 
 func DownloadDependency() {
@@ -131,10 +130,9 @@ func Start() (Pty, error) {
 	if !isWin10 {
 		tty, err := winpty.OpenDefault(path, shellPath)
 		return &winPTY{tty: tty}, err
-	} else {
-		tty, err := conpty.Start(shellPath, conpty.ConPtyWorkDir(path))
-		return &conPty{tty: tty}, err
 	}
+	tty, err := conpty.Start(shellPath, conpty.ConPtyWorkDir(path))
+	return &conPty{tty: tty}, err
 }
 
 func (w *winPTY) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
1. 修改 `monitor.UpdateIP` 逻辑以确保双栈ip显示格式永远为 ipv4/ipv6，和之前的版本一致
2. 抽离出 `monitor.GetState` 中的获取连接数代码
3. 部分小更改，减少一些不必要的操作