### PR TITLE
fix: GeoQueryIP logic

### DIFF
--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -46,6 +46,9 @@ func UpdateIP(useIPv6CountryCode bool, period uint32) {
 
 		if !useIPv6CountryCode {
 			GeoQueryIP = ipv4
+			if GeoQueryIP == "" {
+				GeoQueryIP = ipv6
+			}
 		} else {
 			GeoQueryIP = ipv6
 		}


### PR DESCRIPTION
修复没加 `--use-ipv6-countrycode` 参数导致 ipv6 only 机器显示不了 ip 问题
（加了参数的人应该不可能会没 v6 地址 所以下面没做判断）