### PR TITLE
feat: add option to disable syslog logging

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -156,6 +156,7 @@ func init() {
 	agentCmd.PersistentFlags().Uint32VarP(&agentCliParam.IPReportPeriod, "ip-report-period", "u", 30*60, "本地IP更新间隔, 上报频率依旧取决于report-delay的值")
 	agentCmd.Flags().BoolVarP(&agentCliParam.Version, "version", "v", false, "查看当前版本号")
 
+	// https://github.com/golang/go/issues/59229
 	if runtime.GOOS == "darwin" {
 		agentCliParam.DisableSyslog = true
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -332,8 +332,6 @@ func runService(action string, flags []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-	} else {
-		util.Logger = service.ConsoleLogger
 	}
 
 	go func() {

--- a/cmd/agent/service.go
+++ b/cmd/agent/service.go
@@ -87,6 +87,7 @@ func serviceActions(cmd *cobra.Command, args []string) {
 		{agentCliParam.UseIPv6CountryCode, "--use-ipv6-countrycode", ""},
 		{agentConfig.GPU, "--gpu", ""},
 		{agentCliParam.UseGiteeToUpgrade, "--gitee", ""},
+		{agentCliParam.DisableSyslog, "--disable-syslog", ""},
 		{agentCliParam.IPReportPeriod != 30*60, "-u", fmt.Sprint(agentCliParam.IPReportPeriod)},
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -21,11 +20,6 @@ func IsWindows() bool {
 
 func Println(enabled bool, v ...interface{}) {
 	if enabled {
-		if runtime.GOOS != "darwin" {
-			Logger.Infof("NEZHA@%s>> %v", time.Now().Format("2006-01-02 15:04:05"), fmt.Sprint(v...))
-		} else {
-			fmt.Printf("NEZHA@%s>> ", time.Now().Format("2006-01-02 15:04:05"))
-			fmt.Println(v...)
-		}
+		Logger.Infof("NEZHA@%s>> %v", time.Now().Format("2006-01-02 15:04:05"), fmt.Sprint(v...))
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	Json   = jsoniter.ConfigCompatibleWithStandardLibrary
-	Logger service.Logger
+	Json                  = jsoniter.ConfigCompatibleWithStandardLibrary
+	Logger service.Logger = service.ConsoleLogger
 )
 
 func IsWindows() bool {


### PR DESCRIPTION
增加选项禁用写入日志到 syslog，可以避免缺失 syslog 功能的系统出现错误 `Unix syslog delivery error`
默认禁用（macOS 由于注释中提到的原因总是开启），如非必需不建议使用这个选项