### PR TITLE
优化 TCPPing 延迟统计精度

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -495,7 +495,7 @@ func handleTcpPingTask(task *pb.Task, result *pb.TaskResult) {
 		result.Data = err.Error()
 	} else {
 		conn.Close()
-		result.Delay = float32(time.Since(start).Milliseconds())
+		result.Delay = float32(time.Since(start).Microseconds()) / 1000.0
 		result.Successful = true
 	}
 }


### PR DESCRIPTION
原有 TCPPing 延迟计算是 `time.Since(start).Milliseconds()`，意味着 0.x ms 的情况均被统计为 0 ms

修改后，与现有 ICMP Ping 的延迟精度一致