### PR TITLE
fix: do not kill wrong process group

### DIFF
--- a/pkg/processgroup/process_group.go
+++ b/pkg/processgroup/process_group.go
@@ -47,8 +47,9 @@ func killChildProcess(c *exec.Cmd) {
 	if err != nil {
 		// Fall-back on error. Kill the main process only.
 		c.Process.Kill()
+	} else {
+		// Kill the whole process group.
+		syscall.Kill(-pgid, syscall.SIGTERM)
 	}
-	// Kill the whole process group.
-	syscall.Kill(-pgid, syscall.SIGTERM)
 	c.Wait()
 }


### PR DESCRIPTION
`getpgid(2)` 如错误会返回 -1，进而会把 pid 1 杀死