### PR TITLE
增加disable_internet判断是否只有内网，如果是内网直接本地获取ipv4

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -43,6 +43,7 @@ type AgentConfig struct {
 	IPReportPeriod              uint32          `koanf:"ip_report_period" json:"ip_report_period"`               // IP上报周期
 	SelfUpdatePeriod            uint32          `koanf:"self_update_period" json:"self_update_period"`           // 自动更新周期
 	CustomIPApi                 []string        `koanf:"custom_ip_api" json:"custom_ip_api,omitempty"`           // 自定义 IP API
+	Disable_Internet            bool            `koanf:"disable_internet" json:"disable_internet"`               // 是否内网环境 且无互联网访问权限
 
 	k        *koanf.Koanf `json:"-"`
 	filePath string       `json:"-"`


### PR DESCRIPTION
只有内网并且没有互联网访问的服务器中，获取IP请求
cfList = []string{
		"https://blog.cloudflare.com/cdn-cgi/trace",
		"https://developers.cloudflare.com/cdn-cgi/trace",
		"https://hostinger.com/cdn-cgi/trace",
		"https://ahrefs.com/cdn-cgi/trace",
	}
会超时，导致前端获取不到ip地址并且一会在线一会离线。
增加disable_internet设置项，为true时，判断为无互联网，直接从本地获取ipv4地址。
![image](https://github.com/user-attachments/assets/b060c2eb-a982-4bef-b132-2e3ec6eb6bca)
