### PR TITLE
fix: temperature always failed

### DIFF
--- a/pkg/monitor/temperature/temperature.go
+++ b/pkg/monitor/temperature/temperature.go
@@ -2,6 +2,7 @@ package temperature
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -18,9 +19,12 @@ var sensorIgnoreList = []string{
 
 func GetState(_ context.Context) ([]model.SensorTemperature, error) {
 	temperatures, err := sensors.SensorsTemperatures()
-	if err != nil {
-		return nil, fmt.Errorf("SensorsTemperatures: %v", err)
-	}
+        if err != nil {
+                var sensorsWarnings *sensors.Warnings
+                if !errors.As(err, &sensorsWarnings) {
+                        return nil, fmt.Errorf("SensorsTemperatures: %v", err)
+                }
+        }
 
 	var tempStat []model.SensorTemperature
 	for _, t := range temperatures {


### PR DESCRIPTION
在某些机型获取温度时会产生警告，导致代码直接进入错误处理而无法获得温度，按照 https://github.com/shirou/gopsutil/issues/1429 的方法进行修复。

```
Dec 24 21:37:03 Plana nezha-agent[1423227]: NEZHA@2024-12-24 21:37:03>> 正在更新本地缓存IP信息
Dec 24 21:37:03 Plana nezha-agent[1423227]: NEZHA@2024-12-24 21:37:03>> monitor error: SensorsTemperatures: Number of warnings: 1, type: 4, attempt: 1
Dec 24 21:37:08 Plana nezha-agent[1423227]: NEZHA@2024-12-24 21:37:08>> monitor error: SensorsTemperatures: Number of warnings: 1, type: 4, attempt: 2
Dec 24 21:37:12 Plana nezha-agent[1423227]: NEZHA@2024-12-24 21:37:12>> monitor error: SensorsTemperatures: Number of warnings: 1, type: 4, attempt: 3
```

修复前我的两台 Debian 12.8 Proxmox VE 宿主机（分别是 Intel N5105 和 AMD 8700G）均无法获取温度，修复后温度获取正常。

| Intel N5105 | AMD 8700G |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/62ec1a62-d018-4ba2-a0c9-90984f0e9d3c) | ![image](https://github.com/user-attachments/assets/adb5f715-7610-4af8-b526-9b16a65c86f7) |
