### PR TITLE
将cflist改为无实际业务域名以方便TUN代理过滤

### DIFF
--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -15,10 +15,13 @@ import (
 
 var (
 	cfList = []string{
-		"https://blog.cloudflare.com/cdn-cgi/trace",
-		"https://developers.cloudflare.com/cdn-cgi/trace",
-		"https://hostinger.com/cdn-cgi/trace",
-		"https://ahrefs.com/cdn-cgi/trace",
+		"https://pt.cloudflare.com/cdn-cgi/trace"，
+		"https://sv.cloudflare.com/cdn-cgi/trace",
+		"https://ru.cloudflare.com/cdn-cgi/trace",
+		"https://hu.cloudflare.com/cdn-cgi/trace",
+		
+		"https://ns.cloudflare.com/cdn-cgi/trace",
+		"https://dns.cloudflare.com/cdn-cgi/trace",
 	}
 	CustomEndpoints               []string
 	GeoQueryIP, CachedCountryCode string

--- a/pkg/monitor/myip.go
+++ b/pkg/monitor/myip.go
@@ -19,9 +19,7 @@ var (
 		"https://sv.cloudflare.com/cdn-cgi/trace",
 		"https://ru.cloudflare.com/cdn-cgi/trace",
 		"https://hu.cloudflare.com/cdn-cgi/trace",
-		
 		"https://ns.cloudflare.com/cdn-cgi/trace",
-		"https://dns.cloudflare.com/cdn-cgi/trace",
 	}
 	CustomEndpoints               []string
 	GeoQueryIP, CachedCountryCode string


### PR DESCRIPTION
因为我发现原先这些域名是在浏览器上或者其他类型的业务上会请求的，所以不能影响这部分的访问
于是我翻遍了cloudflare所有的子域名 发现有`302到主站`和`CNAME Cross-User Banned`的域名
这类域名通常不影响浏览器或者其他类型的业务 也方便TUN代理写DOMAIN类规则使用

以Mihomo内核配置文件为例
```yaml
rule-providers:
  nezha-agent-cflist:
    type: inline
    behavior: classical
    payload:
     - "DOMAIN,pt.cloudflare.com"
     - "DOMAIN,sv.cloudflare.com"
     - "DOMAIN,ru.cloudflare.com"
     - "DOMAIN,hu.cloudflare.com"
     - "DOMAIN,ns.cloudflare.com"
rules:
  - RULE-SET,nezha-agent-cflist,DIRECT
```