### PR TITLE
increase log level for darwin

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -366,7 +366,7 @@ func runService(action string, path string) {
 	}
 	prg.Service = s
 
-	serviceLogger, err := s.Logger(nil)
+	serviceLogger, err := logger.NewNezhaServiceLogger(s, nil)
 	if err != nil {
 		printf("获取 service logger 时出错: %+v", err)
 		logger.InitDefaultLogger(agentConfig.Debug, service.ConsoleLogger)

--- a/pkg/logger/service_logger_wrapper.go
+++ b/pkg/logger/service_logger_wrapper.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package logger
+
+import (
+	"github.com/nezhahq/service"
+)
+
+func NewNezhaServiceLogger(s service.Service, errs chan<- error) (service.Logger, error) {
+	return s.Logger(errs)
+}

--- a/pkg/logger/service_logger_wrapper_darwin.go
+++ b/pkg/logger/service_logger_wrapper_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package logger
+
+import (
+	"github.com/nezhahq/service"
+)
+
+type serviceLogger struct {
+	service.Logger
+}
+
+// darwin will ignore info level logs by default
+func (s *serviceLogger) Info(v ...any) error {
+	return s.Warning(v...)
+}
+
+func (s *serviceLogger) Infof(format string, v ...any) error {
+	return s.Warningf(format, v...)
+}
+
+func NewNezhaServiceLogger(s service.Service, errs chan<- error) (service.Logger, error) {
+	logger, err := s.Logger(errs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &serviceLogger{logger}, nil
+}


### PR DESCRIPTION
macOS system.log 默认不显示 info 等级的日志，因此将 `Info` 和 `Infof` 的日志等级临时提升到 warning