### PR TITLE
drop gpu monitoring support for darwin amd64

### DIFF
--- a/pkg/monitor/gpu/gpu_fallback.go
+++ b/pkg/monitor/gpu/gpu_fallback.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux && !windows
+//go:build !(darwin && arm64) && !linux && !windows
 
 package gpu
 


### PR DESCRIPTION
因为缺少测试机器而无法继续维护该部分功能，并且此部分可能存在 bug，故将相关代码移除