### PR TITLE
fix(auth): send hyphenated agent metadata

### DIFF
--- a/model/auth.go
+++ b/model/auth.go
@@ -28,7 +28,12 @@ func (a *AuthHandler) GetRequestMetadata(ctx context.Context, uri ...string) (ma
 		return nil, ErrAuthCredentialsNotConfigured
 	}
 	secret, uuid := a.Credentials()
-	return map[string]string{"client_secret": secret, "client_uuid": uuid}, nil
+	return map[string]string{
+		"client-secret": secret,
+		"client-uuid":   uuid,
+		"client_secret": secret,
+		"client_uuid":   uuid,
+	}, nil
 }
 
 func (a *AuthHandler) RequireTransportSecurity() bool {

--- a/model/auth_test.go
+++ b/model/auth_test.go
@@ -25,6 +25,9 @@ func TestAuthHandlerReadsCredentialsPerCall(t *testing.T) {
 	if md["client_secret"] != "old-secret" {
 		t.Fatalf("expected old-secret, got %q", md["client_secret"])
 	}
+	if md["client-secret"] != "old-secret" {
+		t.Fatalf("expected old-secret in hyphenated metadata, got %q", md["client-secret"])
+	}
 
 	// Rotate the credential the way handleApplyConfigTask's reload would after
 	// the save-then-swap completes.
@@ -36,6 +39,9 @@ func TestAuthHandlerReadsCredentialsPerCall(t *testing.T) {
 	}
 	if md["client_secret"] != "new-secret" {
 		t.Fatalf("AuthHandler must read the closure on every call to pick up rotation, got %q", md["client_secret"])
+	}
+	if md["client-secret"] != "new-secret" {
+		t.Fatalf("AuthHandler must update hyphenated metadata on every call, got %q", md["client-secret"])
 	}
 }
 
@@ -85,9 +91,31 @@ func TestAuthHandlerCoherentCredentialPair(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetRequestMetadata: %v", err)
 		}
-		s, u := md["client_secret"], md["client_uuid"]
+		s, u := md["client-secret"], md["client-uuid"]
 		if (s == "secret-A" && u != "uuid-A") || (s == "secret-B" && u != "uuid-B") {
 			t.Fatalf("torn credential pair: secret=%q uuid=%q (must come from a single snapshot)", s, u)
+		}
+	}
+}
+
+func TestAuthHandlerEmitsLegacyAndHyphenatedMetadata(t *testing.T) {
+	a := &AuthHandler{
+		Credentials: func() (string, string) { return "secret", "uuid" },
+	}
+
+	md, err := a.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("GetRequestMetadata: %v", err)
+	}
+
+	for _, key := range []string{"client-secret", "client_secret"} {
+		if md[key] != "secret" {
+			t.Fatalf("%s = %q, want secret", key, md[key])
+		}
+	}
+	for _, key := range []string{"client-uuid", "client_uuid"} {
+		if md[key] != "uuid" {
+			t.Fatalf("%s = %q, want uuid", key, md[key])
 		}
 	}
 }


### PR DESCRIPTION
## Why

Caddy v2.11.4 drops request headers whose names contain underscores before the handler chain runs.

Relevant Caddy source:
https://github.com/caddyserver/caddy/blob/v2.11.4/modules/caddyhttp/server.go#L497-L508

Nezha Agent currently sends gRPC auth metadata as `client_secret` and `client_uuid`. When the agent connects through Caddy v2.11.4, those metadata headers can be removed before reaching the dashboard, causing authentication failure and offline agents.

This is not something users can fix in Caddyfile, because the headers are removed before `reverse_proxy` sees the request.

## What changed

Send hyphenated metadata keys in addition to the legacy underscore keys:

- new: `client-secret`, `client-uuid`
- legacy: `client_secret`, `client_uuid`

The legacy keys are still emitted for compatibility with dashboards that have not yet been upgraded.

## Compatibility

This supports mixed-version deployments:

- old dashboard + new agent: still receives legacy underscore keys
- new dashboard + old agent: dashboard still accepts legacy keys
- new dashboard + new agent behind Caddy v2.11.4: uses hyphenated keys successfully

Companion dashboard PR: https://github.com/nezhahq/nezha/pull/1197

## Testing

- `go test ./model`
