### PR TITLE
fix monitor swap metrics on darwin

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -107,12 +107,12 @@ func GetHost() *model.Host {
 		printf("mem.VirtualMemory error: %v", err)
 	} else {
 		ret.MemTotal = mv.Total
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 			ret.SwapTotal = mv.SwapTotal
 		}
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		ms, err := mem.SwapMemory()
 		if err != nil {
 			printf("mem.SwapMemory error: %v", err)
@@ -144,12 +144,12 @@ func GetState(skipConnectionCount bool, skipProcsCount bool) *model.HostState {
 		} else {
 			ret.MemUsed = vm.Used
 		}
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 			ret.SwapUsed = vm.SwapTotal - vm.SwapFree
 		}
 	}
-	if runtime.GOOS == "windows" {
-		// gopsutil 在 Windows 下不能正确取 swap
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// gopsutil 在 Windows/Darwin 下通过 SwapMemory 获取 swap
 		ms, err := mem.SwapMemory()
 		if err != nil {
 			printf("mem.SwapMemory error: %v", err)


### PR DESCRIPTION
## Problem

On macOS, the agent reports `swap_total` and `swap_used` as 0 even when the system is actively using swap. As a result, the dashboard shows `no swap` for Darwin hosts with active swap usage.

## Cause

The agent currently reads swap data from `mem.VirtualMemory()` on non-Windows platforms. However, gopsutil does not populate `SwapTotal`/`SwapFree` in the Darwin `VirtualMemory()` implementation. Darwin swap data is available through `mem.SwapMemory()`, which reads `vm.swapusage`.

## Fix

Handle Darwin the same way as the existing Windows special case for swap collection: use `mem.SwapMemory()` for Darwin swap total and used values, while keeping the existing `VirtualMemory()` swap path for other non-Windows platforms.